### PR TITLE
Error when no tests found

### DIFF
--- a/src/FinderCommand.php
+++ b/src/FinderCommand.php
@@ -33,6 +33,7 @@ class FinderCommand extends Command {
     $bootstrap = $input->getOption('bootstrap-file');
     include_once $bootstrap;
     $testSuites = $input->getArgument('test-suite');
+    $testFilenames = [];
 
     $config = (new Loader())->load($configFile);
 


### PR DESCRIPTION
When no tests are found the following warning is thrown:

```
Warning: Undefined variable $testFilenames in /data/vendor/previousnext/phpunit-finder/src/FinderCommand.php on line 51
```

On PHP 8.0 and above this becomes a fatal error:

```
Fatal error: Uncaught TypeError: array_unique(): Argument #1 ($array) must be of type array, null given in /data/vendor/previousnext/phpunit-finder/src/FinderCommand.php:51
```

If this is piped in to `circleci tests split` it results in a failed build.